### PR TITLE
Build old nasm version from source on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,4 +212,4 @@ async function fetchBuffer(url) {
     return buffer
 }
 
-main().catch(() => core.setFailed(`could not install NASM: ${e}`))
+main().catch((e) => core.setFailed(`could not install NASM: ${e}`))

--- a/index.js
+++ b/index.js
@@ -37,6 +37,19 @@ async function main() {
         fs.mkdirSync(absNasmDir, {recursive: true})
     }
 
+    // NASM publishes borked macOS binaries for older releases. Modern macOS
+    // does not support 32-bit binaries and for some reason throws "Bad CPU type"
+    // errors if a binary contain 32-bit code slice. Build old versions from source.
+    if (platform == 'macos') {
+        let match = version.match(/^(\d+)\.(\d+)/)
+        let major = match[1]
+        let minor = match[2]
+        if (major < 2 || (major == 2 && minor < 14)) {
+            core.debug(`nasm binary version is not available on macOS: ${version}`)
+            try_binary = false
+        }
+    }
+
     async function downloadBinary() {
         const url = new URL(`https://www.nasm.us/pub/nasm/releasebuilds/${version}/${platform}/nasm-${version}-${platform}.zip`)
         const buffer = await fetchBuffer(url)

--- a/index.js
+++ b/index.js
@@ -212,4 +212,4 @@ async function fetchBuffer(url) {
     return buffer
 }
 
-main().catch(() => core.setFailed('could not install NASM'))
+main().catch(() => core.setFailed(`could not install NASM: ${e}`))

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ async function main() {
     // NASM publishes borked macOS binaries for older releases. Modern macOS
     // does not support 32-bit binaries and for some reason throws "Bad CPU type"
     // errors if a binary contain 32-bit code slice. Build old versions from source.
-    if (platform == 'macos') {
+    if (platform == 'macosx') {
         let match = version.match(/^(\d+)\.(\d+)/)
         let major = parseInt(match[1])
         let minor = parseInt(match[2])

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ async function main() {
     const destination = core.getInput('destination') || 'nasm'
     const from_source = core.getInput('from-source')
     // Yeah, these are strings... JavaScript at its finest
-    const try_binary = (from_source != 'true')
-    const try_source = (from_source != 'false')
+    var try_binary = (from_source != 'true')
+    var try_source = (from_source != 'false')
     const platform = selectPlatform(core.getInput('platform'))
 
     const homedir = require('os').homedir()

--- a/index.js
+++ b/index.js
@@ -42,11 +42,17 @@ async function main() {
     // errors if a binary contain 32-bit code slice. Build old versions from source.
     if (platform == 'macos') {
         let match = version.match(/^(\d+)\.(\d+)/)
-        let major = match[1]
-        let minor = match[2]
+        let major = parseInt(match[1])
+        let minor = parseInt(match[2])
         if (major < 2 || (major == 2 && minor < 14)) {
-            core.debug(`nasm binary version is not available on macOS: ${version}`)
-            try_binary = false
+            core.info(`Requested NASM version ${version} has incompatible prebuilt binaries.`)
+            core.info(`Only source builds are supported on macOS.`)
+            if (try_source) {
+                core.info(`Will try building from source.`)
+                try_binary = false
+            } else {
+                core.warning(`Trying binary build at your own risk.`)
+            }
         }
     }
 


### PR DESCRIPTION
It seems that modern macOS versions can't execute old binaries provided by nasm. Let's support only source builds then.