### PR TITLE
CI: Add a weekly run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - release/*
+  schedule:
+    - cron:  '0 6 * * 1'
 
 jobs:
   test-default:


### PR DESCRIPTION
Run the CI every week at monday 06:00 UTC to test changes in GitHubs virtual environments: https://github.com/actions/virtual-environments