### PR TITLE
Converting a warning into info message

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ async function main() {
             made_it = true
         }
         catch (error) {
-            core.warning(`binaries did not work: ${error}`)
+            core.info(`binaries did not work: ${error}`)
         }
     }
     if (try_source && !made_it) {


### PR DESCRIPTION
Prettifying Github Actions page when `binaries did not work`, since anyways we have final `throw new Error("I'm sorry, Dave. I'm afraid I can't do that.")`, if nothing works, which really needs user attention.