### PR TITLE
CI: Add workflow to update package-lock.json every month

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -1,0 +1,27 @@
+name: "Update package-lock.json"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 1 * *' # 1st day of each month at 06:00 UTC
+  push:
+    paths:
+    - 'package.json'
+    - '.github/workflows/update-package-lock.yml'
+
+
+jobs:
+  piplock:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 'lts/*'
+    - run: npm install --package-lock
+    - run: npm audit fix
+    - uses: peter-evans/create-pull-request@v3
+      with:
+        title: "Update package-lock.json (dependencies)"
+        branch: update-package-lock
+        base: master
+        commit-message: "[Bot] Update package-lock.json dependencies"


### PR DESCRIPTION
Adds a workflow that generates a up to date lockfile based on the current `package.json`. The workflow runs every 1st day of each month, and if either this configuration or the `package.json` itself is modified. A run will open a PR with the updated `package-lock.json`, and if a PR is already open it will update that PR.

By running and opening/updating a PR each month it's ensured the `package-lock.json` stays up to date and updated frequently at convenient times, while reproducible builds are still ensured.