### PR TITLE
Tweak branch for package-lock.json PRs

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -23,5 +23,5 @@ jobs:
       with:
         title: "Update package-lock.json (dependencies)"
         branch: update-package-lock
-        base: master
+        base: release/v1
         commit-message: "[Bot] Update package-lock.json dependencies"


### PR DESCRIPTION
If this is running on `release/v1` and finds something, PRs should target `release/v1`, not `master`.

Probably something like `${{ github.ref }}` would be better, but I don't want to go down the rabbit hole of running the workflow 100500 times to debug it.