### PR TITLE
Install only `--production` deps on `release/v1` branch

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 'lts/*'
-    - run: npm install --package-lock
+    - run: npm install --package-lock --production
     - run: npm audit fix
     - uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
No need to pull in linters, etc., since this branch has only dependencies necessary to execute the action.