### PR TITLE
Do not audit `dev` deps on `release/v1` branch

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: 'lts/*'
     - run: npm install --package-lock --production
-    - run: npm audit fix
+    - run: npm audit fix --omit dev
     - uses: peter-evans/create-pull-request@v3
       with:
         title: "Update package-lock.json (dependencies)"


### PR DESCRIPTION
Oh, right... Now `npm audit fix` tries to install all the stuff. Nonono, don't touch development dependencies.