### PR TITLE
Update to Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
       One of: `dos`, `linux`, `macosx`, `win32`, `win64`
       See https://www.nasm.us/pub/nasm/releasebuilds/ for available platforms.
 runs:
-  using: node16
+  using: node20
   main: index.js
 branding:
   icon: archive


### PR DESCRIPTION
Nothing is expected to break with this. GitHub is aiming at finishing migration to Node.js 20 around spring 2024, better get it going...